### PR TITLE
Change the preview perm to view_newsletter

### DIFF
--- a/newsletters/templates/newsletters/index.html
+++ b/newsletters/templates/newsletters/index.html
@@ -17,7 +17,7 @@
     </p>
     <div class="list-group mb-3">
         {% for newsletter in object_list %}
-            {% if perms.newsletters.change_newsletter or newsletter.ispublished %}
+            {% if perms.newsletters.view_newsletter or newsletter.ispublished %}
                 <a href="{% url 'newsletters:newsletters_detail' newsletter.id %}"
                    class="list-group-item list-group-item-action">
                     <span class="d-flex flex-column"><strong>

--- a/newsletters/views.py
+++ b/newsletters/views.py
@@ -36,7 +36,7 @@ class Detail(generic.DetailView):
 
     def get_object(self, queryset=None):
         obj = super(Detail, self).get_object()
-        if not obj.ispublished and not self.request.user.has_perm('newsletters.change_newsletter'):
+        if not obj.ispublished and not self.request.user.has_perm('newsletters.view_newsletter'):
             raise Http404
         return obj
 


### PR DESCRIPTION
Change the perm needed to view newsletters before being published so that it can be separated from editing past newsletters.