### PR TITLE
Tiny minutes UX, exec page string and delayed event notifications

### DIFF
--- a/exec/templates/exec/index.html
+++ b/exec/templates/exec/index.html
@@ -14,6 +14,7 @@
 {% endblock %}
 
 {% block body %}
+    {{ exec_history|parse_md_safe }}
     <ul class="list-unstyled">
         {% for role in execs %}
             {% if role.incumbent %}

--- a/exec/templates/exec/index.html
+++ b/exec/templates/exec/index.html
@@ -1,5 +1,6 @@
 {% extends 'tgrsite/main.html' %}
 {% load markdown_tags %}
+{% load property_tags %}
 {% block title %}
     Exec page
 {% endblock %}
@@ -14,7 +15,7 @@
 {% endblock %}
 
 {% block body %}
-    {{ exec_history|parse_md_safe }}
+    {% text_setting "exec_history" as history %}{{ history|parse_md_safe }}
     <ul class="list-unstyled">
         {% for role in execs %}
             {% if role.incumbent %}

--- a/exec/views.py
+++ b/exec/views.py
@@ -3,6 +3,8 @@ from django.urls import reverse_lazy
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.views.generic import ListView, UpdateView
+from website_settings.models import TextProperty
+
 
 from .forms import ExecBioForm
 from .models import ExecRole
@@ -17,6 +19,8 @@ class Index(ListView):
     def get_context_data(self, *args, **kwargs):
         ctxt = super().get_context_data(*args, **kwargs)
         ctxt['resp'] = 'full' in self.request.GET
+        history, d = TextProperty.objects.get_or_create(key='exec_history', defaults="")
+        ctxt['exec_history'] = str(history.value)
         return ctxt
 
 

--- a/exec/views.py
+++ b/exec/views.py
@@ -19,8 +19,6 @@ class Index(ListView):
     def get_context_data(self, *args, **kwargs):
         ctxt = super().get_context_data(*args, **kwargs)
         ctxt['resp'] = 'full' in self.request.GET
-        history, d = TextProperty.objects.get_or_create(key='exec_history', defaults="")
-        ctxt['exec_history'] = str(history.value)
         return ctxt
 
 

--- a/minutes/models.py
+++ b/minutes/models.py
@@ -51,7 +51,7 @@ class Folder(models.Model):
 
 class Meeting(models.Model):
     name = models.CharField(max_length=30,
-                            help_text="Letters, numbers or underscores only",
+                            help_text="This is the name that appears in the URL - week_n is a sensible example. Letters, numbers or underscores only",
                             validators=[RegexValidator("^[a-zA-Z0-9][a-zA-Z0-9-_]*$",
                                                        "This may only contain letters, numbers or underscores")])
     title = models.CharField(max_length=80)

--- a/minutes/models.py
+++ b/minutes/models.py
@@ -51,7 +51,7 @@ class Folder(models.Model):
 
 class Meeting(models.Model):
     name = models.CharField(max_length=30,
-                            help_text="This is the name that appears in the URL - week_n is a sensible example. Letters, numbers or underscores only",
+                            help_text="This is the name that appears in the URL - Week_n is a sensible example. Letters, numbers or underscores only",
                             validators=[RegexValidator("^[a-zA-Z0-9][a-zA-Z0-9-_]*$",
                                                        "This may only contain letters, numbers or underscores")])
     title = models.CharField(max_length=80)

--- a/minutes/templates/minutes/detail.html
+++ b/minutes/templates/minutes/detail.html
@@ -37,12 +37,12 @@
         <div class="btn-group btn-block mb-3">
             {% if prev %}
                 <a class="btn btn-outline-primary" href="{{ prev.get_absolute_url }}"><i
-                        class="fas fa-angle-left"></i><span class="sr-only">Previous</span></a>
+                        class="fas fa-angle-left"></i> <span>Previous</span></a>
             {% endif %}
 
             {% if next %}
-                <a class="btn btn-outline-primary" href="{{ next.get_absolute_url }}"><i
-                        class="fas fa-angle-right"></i><span class="sr-only">Next</span></a>
+                <a class="btn btn-outline-primary" href="{{ next.get_absolute_url }}"><span>Next</span> <i
+                        class="fas fa-angle-right"></i></a>
             {% endif %}
         </div>
     {% endif %}

--- a/pages/models.py
+++ b/pages/models.py
@@ -16,7 +16,7 @@ class Page(models.Model):
     title = models.CharField(max_length=64, blank=True, help_text='Page title to display in titlebar of browser/tab')
     page_title = models.CharField(max_length=64, blank=True, help_text='Title to appear at the top of the page')
     breadcrumb_child = models.CharField(max_length=64, blank=True, help_text='Child element of the breadcrumb list')
-    body = models.TextField(max_length=16384, blank=True, help_text='Page contents')
+    body = models.TextField(max_length=65536, blank=True, help_text='Page contents')
     head = models.TextField(max_length=16384, blank=True, help_text='Custom HTML to go in the <head> of the page')
     css = models.TextField(max_length=16384, blank=True, help_text='Custom CSS styles for the page')
     leftbar = models.TextField(max_length=16384, blank=True, help_text='Left sidebar contents (use cards)')

--- a/rpgs/forms.py
+++ b/rpgs/forms.py
@@ -43,7 +43,7 @@ class RpgForm(forms.ModelForm):
 class RpgCreateForm(RpgForm):
     class Meta:
         model = Rpg
-        fields = ['title', 'system', 'description', 'players_wanted', 'timeslot', 'location', 'finishes']
+        fields = ['title', 'system', 'description', 'players_wanted', 'timeslot', 'location', 'finishes', 'sent_notif']
         widgets = {
             'description': Textarea(attrs=MD_INPUT),
         }

--- a/rpgs/models.py
+++ b/rpgs/models.py
@@ -33,7 +33,7 @@ class Rpg(models.Model):
                                       help_text="Require users to be verified members to sign up")
     messaging_thread = models.ForeignKey(MessageThread, on_delete=models.SET_NULL, null=True, blank=True)
     sent_notif = models.BooleanField('Should publishing this event notify everyone?', default=True,
-                                      help_text="It is recommended that this should be ticked, since notifying members will help you get players.\n" +
+                                      help_text="It is recommended that this should be ticked, since notifying members will help you get players.<br>" +
                                       "If you do not tick this, you can choose to notify everyone later")
 
     def __str__(self):

--- a/rpgs/models.py
+++ b/rpgs/models.py
@@ -32,6 +32,9 @@ class Rpg(models.Model):
     member_only = models.BooleanField(default=False,
                                       help_text="Require users to be verified members to sign up")
     messaging_thread = models.ForeignKey(MessageThread, on_delete=models.SET_NULL, null=True, blank=True)
+    sent_notif = models.BooleanField('Should publishing this event notify everyone?', default=True,
+                                      help_text="It is recommended that this should be ticked, since notifying members will help you get players.\n" +
+                                      "If you do not tick this, you can choose to notify everyone later")
 
     def __str__(self):
         return self.title

--- a/rpgs/templates/rpgs/parts/event.html
+++ b/rpgs/templates/rpgs/parts/event.html
@@ -108,7 +108,8 @@
                 <form id="event_notify" action="{% url "rpgs:notify" rpg.pk %}" method="post">
                     {% csrf_token %}
                 </form>
-                <button form="event_notify" class="btn btn-outline-success" href="{% url "rpgs:notify" rpg.pk %}"><i
+                <button type="submit" form="event_notify" class="btn btn-outline-success" href="{% url "rpgs:notify" rpg.pk %}" 
+                    data-toggle="tooltip" title="Notify everyone on the website and Discord."><i
                         class="fas fa-exclamation-triangle"></i> <span>Notify Everyone</span></button>
                 {% endif %}
             </div>

--- a/rpgs/templates/rpgs/parts/event.html
+++ b/rpgs/templates/rpgs/parts/event.html
@@ -104,8 +104,17 @@
                         {% endif %}
                     </div>
                 {% endif %}
+                {% if manager and not rpg.sent_notif %}
+                <form id="event_notify" action="{% url "rpgs:notify" rpg.pk %}" method="post">
+                    {% csrf_token %}
+                </form>
+                <button form="event_notify" class="btn btn-outline-success" href="{% url "rpgs:notify" rpg.pk %}"><i
+                        class="fas fa-exclamation-triangle"></i> <span>Notify Everyone</span></button>
+                {% endif %}
             </div>
             {% if manager %}
+                
+
                 <form method="post" class="d-flex flex-grow-1 mx-0 mb-2 mb-sm-0 ml-sm-3" id="event_add_to"
                       action="{% url "rpgs:add_to" rpg.pk %}">
                     <div class="form-group d-flex flex-grow-1 m-0 justify-content-around align-items-center">

--- a/rpgs/templates/rpgs/parts/event.html
+++ b/rpgs/templates/rpgs/parts/event.html
@@ -93,8 +93,16 @@
         {% endif %}
         <div class="card-footer d-flex flex-column flex-sm-row justify-content-between align-items-sm-center">
             <div class="flex-grow-1 mb-0">
-                {% if user.member not in rpg.game_masters.all %}
-                    <div class="btn-group btn-block">
+                <div class="btn-group btn-block">
+                    {% if manager and not rpg.sent_notif %}
+                    <form id="event_notify" action="{% url "rpgs:notify" rpg.pk %}" method="post">
+                        {% csrf_token %}
+                    </form>
+                    <button type="submit" form="event_notify" class="btn btn-outline-success" href="{% url "rpgs:notify" rpg.pk %}" 
+                        data-toggle="tooltip" title="Notify everyone on the website and Discord."><i
+                            class="fas fa-exclamation-triangle"></i> <span>Notify Everyone</span></button>
+                    {% endif %}
+                    {% if user.member not in rpg.game_masters.all %}
                         {% if user.member in rpg.members.all %}
                             <button form="event_leave" type="submit" class="btn btn-outline-warning">Leave</button>
                         {% else %}
@@ -102,20 +110,10 @@
                                 <button form="event_join" type="submit" class="btn btn-outline-success">Join</button>
                             {% endif %}
                         {% endif %}
-                    </div>
-                {% endif %}
-                {% if manager and not rpg.sent_notif %}
-                <form id="event_notify" action="{% url "rpgs:notify" rpg.pk %}" method="post">
-                    {% csrf_token %}
-                </form>
-                <button type="submit" form="event_notify" class="btn btn-outline-success" href="{% url "rpgs:notify" rpg.pk %}" 
-                    data-toggle="tooltip" title="Notify everyone on the website and Discord."><i
-                        class="fas fa-exclamation-triangle"></i> <span>Notify Everyone</span></button>
-                {% endif %}
+                    {% endif %}
+                </div>
             </div>
             {% if manager %}
-                
-
                 <form method="post" class="d-flex flex-grow-1 mx-0 mb-2 mb-sm-0 ml-sm-3" id="event_add_to"
                       action="{% url "rpgs:add_to" rpg.pk %}">
                     <div class="form-group d-flex flex-grow-1 m-0 justify-content-around align-items-center">

--- a/rpgs/urls.py
+++ b/rpgs/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('<int:pk>/delete/', views.Delete.as_view(), name='delete'),
 
     path('<int:pk>/join/', views.Join.as_view(), name='join'),
+    path('<int:pk>/notify/', views.Notify.as_view(), name='notify'),
     path('<int:pk>/leave/', views.Leave.as_view(), name='leave'),
 
     path('<int:pk>/kick/', views.Kick.as_view(), name='kick'),

--- a/rpgs/views.py
+++ b/rpgs/views.py
@@ -137,6 +137,7 @@ class Delete(LoginRequiredMixin, UserPassesTestMixin, SuccessMessageMixin, gener
         return can_manage(self.request.user.member, rpg)
 
 
+# possible TODO: consider if better via UserPassesTestMixin
 class Notify(LoginRequiredMixin, generic.View):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
* Added "Previous" and "Next" labels to minutes buttons, as they were complained about.
* Added help text to clarify the "Name" of minutes.
* Added a text property `exec_history` which is displayed at the top of the Exec page, for adding a link to past exec.
* Added delayed event notifications, which allow you to delay an event notification (shocking) via actively unchecking a checkbox. This then gives you a single-use button (writing to the database that a notification has been sent) for sending that notification later.