### PR TITLE
Draft events and Discord usernames on exec page

### DIFF
--- a/exec/templates/exec/index.html
+++ b/exec/templates/exec/index.html
@@ -24,7 +24,7 @@
                     <div class="card-body">
                         <h4 class="card-title text-center text-sm-left">
                             {{ role.role_title }} -
-                            {% include "parts/render_member.html" with member=role.incumbent fullname=True %}
+                            {% include "parts/render_member.html" with member=role.incumbent fullname=True nobadge=True %}
                             {% if request.user.member == role.incumbent %}
                                 <a class="btn btn-outline-success" href="{% url 'exec:exec_editbio' role.id %}"><i
                                         class="fas fa-pencil-alt"></i></a>

--- a/exec/templates/exec/index.html
+++ b/exec/templates/exec/index.html
@@ -24,7 +24,7 @@
                     <div class="card-body">
                         <h4 class="card-title text-center text-sm-left">
                             {{ role.role_title }} -
-                            {% include "parts/render_member.html" with member=role.incumbent fullname=True nobadge=True %}
+                            {% include "parts/render_member.html" with member=role.incumbent fullname=True nobadge=True discord=True %}
                             {% if request.user.member == role.incumbent %}
                                 <a class="btn btn-outline-success" href="{% url 'exec:exec_editbio' role.id %}"><i
                                         class="fas fa-pencil-alt"></i></a>

--- a/notifications/templates/notifications/index.html
+++ b/notifications/templates/notifications/index.html
@@ -33,7 +33,7 @@
         {% empty %}
             <div class="card">
                 <div class="card-body">
-                    <p class="card-text">Wow, you're all caught up! Enjoy the silence.</p>
+                    <p class="card-text text-muted">Wow, you're all caught up! Enjoy the silence.</p>
                 </div>
             </div>
         {% endfor %}

--- a/rpgs/forms.py
+++ b/rpgs/forms.py
@@ -43,7 +43,7 @@ class RpgForm(forms.ModelForm):
 class RpgCreateForm(RpgForm):
     class Meta:
         model = Rpg
-        fields = ['title', 'system', 'description', 'players_wanted', 'timeslot', 'location', 'finishes', 'sent_notif']
+        fields = ['title', 'system', 'description', 'players_wanted', 'timeslot', 'location', 'finishes', 'published']
         widgets = {
             'description': Textarea(attrs=MD_INPUT),
         }

--- a/rpgs/models.py
+++ b/rpgs/models.py
@@ -8,19 +8,12 @@ from users.models import Member
 from messaging.models import MessageThread
 
 class RpgManager(models.Manager):
-    def accessible(self, member : Optional[Member]):
-        if member:
-            if member.equiv_user.has_perm("rpgs.view_rpg"):
-                return self.all()
-            return self.filter(Q(published=True) | Q(creator__contains=member) | Q(members__contains=member))
-        return self.filter(published=True)
-
     def visible(self, member : Optional[Member]):
         qs = self.filter(unlisted=False)
         if member:
             if member.equiv_user.has_perm("rpgs.view_rpg"):
                 return qs
-            return qs.filter(Q(published=True) | Q(creator__contains=member) | Q(members__contains=member))
+            return qs.filter(Q(published=True) | Q(creator=member) | Q(members=member) | Q(game_masters=member))
         return qs.filter(published=True)
 
 

--- a/rpgs/models.py
+++ b/rpgs/models.py
@@ -32,9 +32,8 @@ class Rpg(models.Model):
     member_only = models.BooleanField(default=False,
                                       help_text="Require users to be verified members to sign up")
     messaging_thread = models.ForeignKey(MessageThread, on_delete=models.SET_NULL, null=True, blank=True)
-    sent_notif = models.BooleanField('Should publishing this event notify everyone?', default=True,
-                                      help_text="It is recommended that this should be ticked, since notifying members will help you get players.<br>" +
-                                      "If you do not tick this, you can choose to notify everyone later")
+    published = models.BooleanField('Publish this event immediately.', default=True,
+                                      help_text="If you do not tick this, your event will be saves as a draft for you to publish later.")
 
     def __str__(self):
         return self.title

--- a/rpgs/templates/rpgs/parts/event.html
+++ b/rpgs/templates/rpgs/parts/event.html
@@ -8,7 +8,7 @@
     <a href="{% url "rpgs:detail" rpg.pk %}"
        class="card-link card-header d-flex flex-column flex-sm-row justify-content-between align-items-center">
         <h5 class="mb-0 text-center text-sm-left">{% if embed and rpg.pinned %}
-            <i class="fas fa-thumbtack"></i> {% endif %}{{ rpg.title }}</h5>
+            <i class="fas fa-thumbtack"></i> {% endif %}{% if not rpg.published %}[DRAFT] {% endif %}{{ rpg.title }}</h5>
         <div class="d-flex flex-column align-items-center align-items-sm-end">
             <span class="mb-0 text-muted text-center text-sm-right">{{ rpg.timeslot }}</span>
             <span class="mb-0 text-muted text-center text-sm-right">{{ rpg.location }}</span>

--- a/rpgs/templates/rpgs/parts/event.html
+++ b/rpgs/templates/rpgs/parts/event.html
@@ -94,13 +94,13 @@
         <div class="card-footer d-flex flex-column flex-sm-row justify-content-between align-items-sm-center">
             <div class="flex-grow-1 mb-0">
                 <div class="btn-group btn-block">
-                    {% if manager and not rpg.sent_notif %}
-                    <form id="event_notify" action="{% url "rpgs:notify" rpg.pk %}" method="post">
+                    {% if manager and not rpg.published %}
+                    <form id="event_publish" action="{% url "rpgs:publish" rpg.pk %}" method="post">
                         {% csrf_token %}
                     </form>
-                    <button type="submit" form="event_notify" class="btn btn-outline-success" href="{% url "rpgs:notify" rpg.pk %}" 
-                        data-toggle="tooltip" title="Notify everyone on the website and Discord."><i
-                            class="fas fa-exclamation-triangle"></i> <span>Notify Everyone</span></button>
+                    <button type="submit" form="event_publish" class="btn btn-outline-success" href="{% url "rpgs:publish" rpg.pk %}" 
+                        data-toggle="tooltip" title="Make this event public, and notify everyone on the website and Discord."><i
+                            class="fas fa-exclamation-triangle"></i> <span>Publish</span></button>
                     {% endif %}
                     {% if user.member not in rpg.game_masters.all %}
                         {% if user.member in rpg.members.all %}

--- a/rpgs/templates/rpgs/parts/event.html
+++ b/rpgs/templates/rpgs/parts/event.html
@@ -8,7 +8,7 @@
     <a href="{% url "rpgs:detail" rpg.pk %}"
        class="card-link card-header d-flex flex-column flex-sm-row justify-content-between align-items-center">
         <h5 class="mb-0 text-center text-sm-left">{% if embed and rpg.pinned %}
-            <i class="fas fa-thumbtack"></i> {% endif %}{% if not rpg.published %}[DRAFT] {% endif %}{{ rpg.title }}</h5>
+            <i class="fas fa-thumbtack"></i> {% endif %}{% if not rpg.published %}<span class="badge badge-primary">DRAFT</span> {% endif %}{{ rpg.title }}</h5>
         <div class="d-flex flex-column align-items-center align-items-sm-end">
             <span class="mb-0 text-muted text-center text-sm-right">{{ rpg.timeslot }}</span>
             <span class="mb-0 text-muted text-center text-sm-right">{{ rpg.location }}</span>

--- a/rpgs/templatetags/rpg_tags.py
+++ b/rpgs/templatetags/rpg_tags.py
@@ -13,6 +13,16 @@ def can_manage(member, rpg):
         member.equiv_user.has_perm('rpgs.change_rpg'))
 
 
+@register.simple_tag
+def can_access(member, rpg):
+    if rpg.published:
+        return True
+    if not member:
+        return False
+    return (member == rpg.creator) or (member in list(rpg.game_masters.all()) or
+        (member in rpg.members.all()) or member.equiv_user.has_perm('rpgs.view_rpg'))
+
+
 # todo: assignment tag is deprecated
 @register.simple_tag(takes_context=True)
 def is_player(context, rpg):

--- a/rpgs/urls.py
+++ b/rpgs/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     path('<int:pk>/delete/', views.Delete.as_view(), name='delete'),
 
     path('<int:pk>/join/', views.Join.as_view(), name='join'),
-    path('<int:pk>/notify/', views.Notify.as_view(), name='notify'),
+    path('<int:pk>/publish/', views.Publish.as_view(), name='publish'),
     path('<int:pk>/leave/', views.Leave.as_view(), name='leave'),
 
     path('<int:pk>/kick/', views.Kick.as_view(), name='kick'),

--- a/rpgs/views.py
+++ b/rpgs/views.py
@@ -207,7 +207,9 @@ class Leave(LoginRequiredMixin, generic.View):
                    'User {} left your game "{}"!'.format(self.request.user.username, rpg.title),
                    reverse('rpgs:detail', kwargs={'pk': self.kwargs['pk']}))
             add_message(self.request, messages.SUCCESS, "You have successfully left that event")
-        return HttpResponseRedirect(reverse('rpgs:detail', kwargs={'pk': self.kwargs['pk']}))
+        if rpg.published:
+            return HttpResponseRedirect(reverse('rpgs:detail', kwargs={'pk': self.kwargs['pk']}))
+        return HttpResponseRedirect(reverse('rpgs:index'))
 
 
 class Kick(LoginRequiredMixin, UserPassesTestMixin, generic.View):

--- a/tgrsite/templates/parts/render_member.html
+++ b/tgrsite/templates/parts/render_member.html
@@ -5,7 +5,7 @@
         <span class="text-nowrap"> ( {% if not avatarless %}<img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">{% endif %}
         <a class="{{ link_class }}" href="{% url 'users:user' member.id %}">{{ member }}</a> {% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
-        {% endif %} )</span>
+        {% endif %}{% if discord and member.discord %}, <i class="fab fa-fw fa-discord"></i>{{ member.discord }}{% endif %} )</span>
     {% else %}
         <span class="text-nowrap">
             {% if not avatarless %}
@@ -15,6 +15,7 @@
         {% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
         {% endif %}
+        {% if discord and member.discord %}<span>(<i class="fab fa-fw fa-discord"></i>{{member.discord}})</span>{% endif %}
         </span>
     {% endif %}
 {% else %}
@@ -23,7 +24,7 @@
         <span class="text-nowrap"> ( {% if not avatarless %}<img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">{% endif %} {{ member }}
             {% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
-        {% endif %} )</span>
+        {% endif %}{% if discord and member.discord %}, <i class="fab fa-fw fa-discord"></i>{{ member.discord }}{% endif %} )</span>
     {% else %}
         <span class="text-nowrap">
         {% if not avatarless %}
@@ -32,6 +33,7 @@
         {{ member }}{% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
         {% endif %}
+        {% if discord and member.discord %}<span>(<i class="fab fa-fw fa-discord"></i>{{member.discord}})</span>{% endif %}
         </span>
     {% endif %}
 

--- a/tgrsite/templates/parts/render_member.html
+++ b/tgrsite/templates/parts/render_member.html
@@ -3,7 +3,7 @@
     {% if member.equiv_user.get_full_name and not short %}
         <span class="text-nowrap">{% if fullname %}{{ member.equiv_user.get_full_name }}{% else %}{{ member.equiv_user.first_name }}{% endif %}</span>
         <span class="text-nowrap"> ( {% if not avatarless %}<img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">{% endif %}
-        <a class="{{ link_class }}" href="{% url 'users:user' member.id %}">{{ member }}</a> {% if member.badge_type %}
+        <a class="{{ link_class }}" href="{% url 'users:user' member.id %}">{{ member }}</a> {% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
         {% endif %} )</span>
     {% else %}
@@ -12,7 +12,7 @@
             <img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">
         {% endif %}
         <a class="{{ link_class }}" href="{% url 'users:user' member.id %}">{{ member }}</a>
-        {% if member.badge_type %}
+        {% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
         {% endif %}
         </span>
@@ -20,7 +20,8 @@
 {% else %}
     {% if member.equiv_user.get_full_name and not short %}
         <span class="text-nowrap">{% if fullname %}{{ member.equiv_user.get_full_name }}{% else %}{{ member.equiv_user.first_name }}{% endif %}</span>
-        <span class="text-nowrap"> ( {% if not avatarless %}<img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">{% endif %} {{ member }} {% if member.badge_type %}
+        <span class="text-nowrap"> ( {% if not avatarless %}<img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">{% endif %} {{ member }}
+            {% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
         {% endif %} )</span>
     {% else %}
@@ -28,7 +29,7 @@
         {% if not avatarless %}
             <img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">
         {% endif %}
-        {{ member }}{% if member.badge_type %}
+        {{ member }}{% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
         {% endif %}
         </span>

--- a/tgrsite/templates/parts/render_member.html
+++ b/tgrsite/templates/parts/render_member.html
@@ -2,10 +2,12 @@
 {% if not nolink %} {# double negative to change default case #}
     {% if member.equiv_user.get_full_name and not short %}
         <span class="text-nowrap">{% if fullname %}{{ member.equiv_user.get_full_name }}{% else %}{{ member.equiv_user.first_name }}{% endif %}</span>
-        <span class="text-nowrap"> ( {% if not avatarless %}<img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">{% endif %}
-        <a class="{{ link_class }}" href="{% url 'users:user' member.id %}">{{ member }}</a> {% if member.badge_type and not nobadge %}
-            <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
-        {% endif %}{% if discord and member.discord %}, <i class="fab fa-fw fa-discord"></i>{{ member.discord }}{% endif %} )</span>
+        <span class="text-nowrap"> ( {% if not avatarless %}<img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">{% endif %} 
+        {% spaceless %}
+        <a class="{{ link_class }}" href="{% url 'users:user' member.id %}">{{ member }}</a>{% comment %}I hate the fact that you have to use comments to do non-rendering linebreaks
+        {% endcomment %}{% if member.badge_type and not nobadge %}<i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>{% endif %}{% comment %}
+        {% endcomment %}{% if discord and member.discord %}, <i class="fab fa-fw fa-discord"></i>{{ member.discord }}{% endif %} )</span>
+        {% endspaceless %}
     {% else %}
         <span class="text-nowrap">
             {% if not avatarless %}
@@ -15,16 +17,17 @@
         {% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
         {% endif %}
-        {% if discord and member.discord %}<span>(<i class="fab fa-fw fa-discord"></i>{{member.discord}})</span>{% endif %}
+        {% if discord and member.discord %}<span>(<i class="fab fa-fw fa-discord"></i>{{member.discord}} )</span>{% endif %}
         </span>
     {% endif %}
 {% else %}
     {% if member.equiv_user.get_full_name and not short %}
         <span class="text-nowrap">{% if fullname %}{{ member.equiv_user.get_full_name }}{% else %}{{ member.equiv_user.first_name }}{% endif %}</span>
         <span class="text-nowrap"> ( {% if not avatarless %}<img class="inline-gravatar" src="{{ member.gravatar }}" alt="Avatar for {{ member }}">{% endif %} {{ member }}
-            {% if member.badge_type and not nobadge %}
-            <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
-        {% endif %}{% if discord and member.discord %}, <i class="fab fa-fw fa-discord"></i>{{ member.discord }}{% endif %} )</span>
+        {% spaceless %}
+        {% if member.badge_type and not nobadge %}<i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>{% endif %}{% comment %}
+        {% endcomment %}{% if discord and member.discord %}, <i class="fab fa-fw fa-discord"></i>{{ member.discord }}{% endif %} )</span>
+        {% endspaceless %}
     {% else %}
         <span class="text-nowrap">
         {% if not avatarless %}
@@ -33,7 +36,7 @@
         {{ member }}{% if member.badge_type and not nobadge %}
             <i class="{{ member.badge_icon }}" title="{{ member.badge_title }}"></i>
         {% endif %}
-        {% if discord and member.discord %}<span>(<i class="fab fa-fw fa-discord"></i>{{member.discord}})</span>{% endif %}
+        {% if discord and member.discord %}<span>(<i class="fab fa-fw fa-discord"></i>{{member.discord}} )</span>{% endif %}
         </span>
     {% endif %}
 

--- a/users/templates/users/view.html
+++ b/users/templates/users/view.html
@@ -66,7 +66,7 @@
                             <a class="list-group-item list-group-item-action d-flex flex-column"
                                href="{% url 'rpgs:detail' rpg.id %}">
                                 <span class="d-flex flex-column flex-sm-row justify-content-between align-items-baseline">
-                                    <strong>{{ rpg.title }}</strong>
+                                    <strong>{% if not rpg.published %}<span class="badge badge-primary">DRAFT</span>{% endif %} {{ rpg.title }}</strong>
                                     <span class="text-muted text-right flex-sm-shrink-0 ml-sm-2">{{ rpg.timeslot }}</span>
                                 </span>
                                 <span class="d-flex flex-column flex-sm-row justify-content-between align-items-baseline">

--- a/users/views.py
+++ b/users/views.py
@@ -51,7 +51,8 @@ class ProfileView(LoginRequiredMixin, DetailView):
         achievements = get_achievements_with_merged(self.object)
         ctxt.update({'recent_threads': Thread.objects.filter(author__id=pk).order_by('-pub_date')[:3],
                      'recent_responses': Response.objects.filter(author__id=pk).order_by('-pub_date')[:3],
-                     'rpgs': Rpg.objects.filter(game_masters__id=pk, is_in_the_past=False),
+                     'rpgs': Rpg.objects.visible(self.request.user.member).filter(game_masters__id=pk, is_in_the_past=False)
+                        .order_by('published', '-pinned', '-created_at')[:10],
                      'achievements': achievements[:5],
                      'achievement_count': len(achievements),
                      'achievement_total': Achievement.objects.filter(is_fair=True).count()})


### PR DESCRIPTION
* Don't render badges next to members on Exec page.
* Render Discord username next to members on Exec page.
* Delayed notifications have been converted to drafts, just by hiding the event if you don't notify immediately and then showing it on publish.