### PR TITLE
Allow comma separation in room links

### DIFF
--- a/timetable/templates/timetable/parts/render_timetable.html
+++ b/timetable/templates/timetable/parts/render_timetable.html
@@ -32,12 +32,7 @@
                 {% for booking in timetable.weeks.all|for_event:event %}
                     <td class="text-center align-middle" colspan="{{ booking.0 }}">
                         {% if booking.1 %}
-                            {% room_link booking.1 as link %}
-                            {% if link %}
-                                <a target="_blank" rel="noopener noreferrer" href="{{ link }}">{{ booking.1 }}</a>
-                            {% else %}
-                                {{ booking.1 }}
-                            {% endif %}
+                            {% room_link booking.1 "" %}
                         {% else %}
                             Not running
                         {% endif %}

--- a/timetable/templates/timetable/parts/widgets/event_widget.html
+++ b/timetable/templates/timetable/parts/widgets/event_widget.html
@@ -9,10 +9,9 @@
         </h4>
         <div class="card-body">
             {% for event in events %}
-                {% room_link event.room as link %}
                 <p class="card-text">
                     <strong>{% if event.url %}<a href="{{ event.url }}">{{ event.title }}</a>{% else %}{{ event.title }}{% endif %}</strong>
-                    ({% if event.room %}{% if link %}<a class="card-link" target="_blank" rel="noopener noreferrer" href="{{ link }}">{{ event.room }}</a>{% else %}{{ event.room }}{% endif %},
+                    ({% if event.room %}{% room_link event.room "card-text" %},
                 {% endif %}Week {{ event.week }}, {{ event.display_date }})
                 </p>
             {% endfor %}

--- a/timetable/templatetags/timetable_tags.py
+++ b/timetable/templatetags/timetable_tags.py
@@ -1,4 +1,6 @@
 from django import template
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 
 from timetable.models import RoomLink
 
@@ -33,15 +35,22 @@ affix_map = {ord(i): None for i in affixes}
 
 
 @register.simple_tag
-def room_link(room):
-    room = room.strip().translate(affix_map)
-    # print(room)
-    if len(room) == 0:
-        return None
-    try:
-        roomlink = RoomLink.objects.get(room__iexact=room)
-    except (RoomLink.DoesNotExist, RoomLink.MultipleObjectsReturned):
-        roomlink = RoomLink.objects.filter(room__icontains=room).first()
-    if roomlink is None:
-        return None
-    return roomlink.url
+def room_link(r, _class):
+    # Remove all special characters from affixes.
+    rooms = r.split(",")
+    rooms = [i.strip().translate(affix_map) for i in rooms]
+    results = []
+    for room in rooms:
+        roomlink = None
+        # print(room)
+        if len(room) > 0:
+            try:
+                roomlink = RoomLink.objects.get(room__iexact=room)
+            except (RoomLink.DoesNotExist, RoomLink.MultipleObjectsReturned):
+                roomlink = RoomLink.objects.filter(room__icontains=room).first()
+        if roomlink is None:
+            results.append(room)
+        else:
+            results.append(format_html('<a target="_blank" rel="noopener noreferrer" href="{}" class="{}">{}</a>',
+                roomlink.url, _class, room))
+    return mark_safe(", ".join(results))

--- a/timetable/templatetags/timetable_tags.py
+++ b/timetable/templatetags/timetable_tags.py
@@ -38,19 +38,19 @@ affix_map = {ord(i): None for i in affixes}
 def room_link(r, _class):
     # Remove all special characters from affixes.
     rooms = r.split(",")
-    rooms = [i.strip().translate(affix_map) for i in rooms]
+    rooms_simple = [i.strip().translate(affix_map) for i in rooms]
     results = []
-    for room in rooms:
+    for (room, simple) in zip(rooms, rooms_simple):
         roomlink = None
         # print(room)
-        if len(room) > 0:
+        if len(simple) > 0:
             try:
-                roomlink = RoomLink.objects.get(room__iexact=room)
+                roomlink = RoomLink.objects.get(room__iexact=simple)
             except (RoomLink.DoesNotExist, RoomLink.MultipleObjectsReturned):
-                roomlink = RoomLink.objects.filter(room__icontains=room).first()
+                roomlink = RoomLink.objects.filter(room__icontains=simple).first()
         if roomlink is None:
             results.append(room)
         else:
             results.append(format_html('<a target="_blank" rel="noopener noreferrer" href="{}" class="{}">{}</a>',
                 roomlink.url, _class, room))
-    return mark_safe(", ".join(results))
+    return mark_safe(",".join(results))


### PR DESCRIPTION
Room links can now be comma separated, e.g. `B2.01, B2.02` will link to both 01 and 02.

Fixes #289 