### PR TITLE
Pages without breadcrumb_child no longer show crumbs

### DIFF
--- a/pages/views.py
+++ b/pages/views.py
@@ -14,6 +14,12 @@ class ViewPage(UserPassesTestMixin, generic.DetailView):
     context_object_name = 'page'
     template_name = "pages/page.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        if self.get_object().breadcrumb_child == "":
+            context["no_breadcrumbs"] = True
+        return context
+
     def test_func(self):
         if not self.test_page_perms():
             return False

--- a/tgrsite/templates/tgrsite/main.html
+++ b/tgrsite/templates/tgrsite/main.html
@@ -49,13 +49,15 @@ THIS IS USED BY THE SITE
 {% endblock %}
 
 {% block breadcrumbs %}
-    <nav aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            {% block breadcrumbs_parents %}
-            {% endblock %}
-            <li class="breadcrumb-item active" aria-current="page">{% block breadcrumbs_child %}{% endblock %}</li>
-        </ol>
-    </nav>
+    {% if not no_breadcrumbs %}
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                {% block breadcrumbs_parents %}
+                {% endblock %}
+                <li class="breadcrumb-item active" aria-current="page">{% block breadcrumbs_child %}{% endblock %}</li>
+            </ol>
+        </nav>
+    {% endif %}
 {% endblock %}
 
 {% block messages %}


### PR DESCRIPTION
Sometimes, it is ideal for a page to not show the breadcrumbs bar. For example, the new proposed index page of the Tabletop website actively has a title element, so doesn't want a title or breadcrumbs. It's easy enough to avoid showing a title by setting it to be blank, but it doesn't work for breadcrumbs - this fix means that if a page has no breadcrumbs, it will not show the bar at all.

Example of it working:

![New Tabletop homepage without crumbs/title](https://user-images.githubusercontent.com/4217801/148623929-e0fdb778-1fd7-4e82-8320-25fb7a2276e0.png)