### PR TITLE
Only allow active members to vote when using date

### DIFF
--- a/users/achievements.py
+++ b/users/achievements.py
@@ -32,7 +32,7 @@ def give_achievement(member: Member, trigger: str, date: datetime = None, reques
     award = AchievementAward.objects.create(
         member=member,
         achievement=achiev,
-        defaults={'achieved_at': date})
+        achieved_at=date)
     notify_achievement(member, achiev.name, request)
     return award
 

--- a/votes/forms.py
+++ b/votes/forms.py
@@ -53,5 +53,6 @@ class MemberTicketForm(Form):
 
 class DateTicketForm(Form):
     date = DateField(widget=SelectDateWidget(),
-                     help_text="Select the date before which their membership should have been verified")
+                     help_text="Select the date before which their membership should have been verified." + \
+                         "Note that this will only select those who are currently members of the society.")
     elections = ModelMultipleChoiceField(Election.objects.all())

--- a/votes/templates/votes/stv_votescreen.html
+++ b/votes/templates/votes/stv_votescreen.html
@@ -64,7 +64,7 @@
                 <div id="sortable_reject" class="card-body">
                     {% for choice in choices %}
                         <div class="card mb-3" data-voteid="{{ choice.formid }}">
-                            <label class="mb-0 card-header" for="{{ choice.formid }}" class="">
+                            <label class="mb-0 card-header" for="{{ choice.formid }}">
                                 <strong>{{ choice.name }}</strong>
                             </label>
                             {% if choice.description|parse_md_text %}

--- a/votes/templates/votes/stv_votescreen.html
+++ b/votes/templates/votes/stv_votescreen.html
@@ -65,7 +65,7 @@
                     {% for choice in choices %}
                         <div class="card mb-3" data-voteid="{{ choice.formid }}">
                             <label class="mb-0 card-header" for="{{ choice.formid }}" class="">
-                                {{ choice.name }}
+                                <strong>{{ choice.name }}</strong>
                             </label>
                             {% if choice.description|parse_md_text %}
                                 <div class="card-body markdown-text">

--- a/votes/views.py
+++ b/votes/views.py
@@ -70,7 +70,7 @@ class DateTicketView(PermissionRequiredMixin, FormView):
     success_url = reverse_lazy('votes:admin')
 
     def form_valid(self, form):
-        for membership in Membership.objects.filter(checked__lte=form.cleaned_data['date']):
+        for membership in Membership.objects.filter(checked__lte=form.cleaned_data['date'], active=True):
             for election in form.cleaned_data['elections']:
                 Ticket.objects.get_or_create(
                     member_id=membership.member_id, election=election)


### PR DESCRIPTION
Verification Date option now disallows members who are no longer active. This avoids old members being allowed to vote in newer elections with tickets handed out by Verification Date.