### PR TITLE
Update vote system to fix several rough edges

### DIFF
--- a/votes/admin.py
+++ b/votes/admin.py
@@ -3,6 +3,12 @@ from django.contrib import admin
 from .models import Election, Candidate, Ticket, FPTPVote, APRVVote, STVVote, STVPreference, STVResult
 
 
+def archive(modeladmin, request, queryset):
+    queryset.filter(open=False).update(archive=True)
+
+archive.short_description = "Archive selected elections (if closed)"
+
+
 class PreferenceInline(admin.StackedInline):
     model = STVPreference
     readonly_fields = ['order', 'candidate']
@@ -36,6 +42,9 @@ class STVResultAdmin(admin.ModelAdmin):
 
 class ElectionAdmin(admin.ModelAdmin):
     inlines = [CandidateInline]
+    actions = [archive]
+    list_filter = ['archive','open', 'vote_type']
+    list_display = ['__str__', 'open','vote_type']
 
 
 # Register your models here.

--- a/votes/admin.py
+++ b/votes/admin.py
@@ -4,7 +4,7 @@ from .models import Election, Candidate, Ticket, FPTPVote, APRVVote, STVVote, ST
 
 
 def archive(modeladmin, request, queryset):
-    queryset.filter(open=False).update(archive=True)
+    queryset.filter(open=False).update(archived=True)
 
 archive.short_description = "Archive selected elections (if closed)"
 
@@ -43,7 +43,7 @@ class STVResultAdmin(admin.ModelAdmin):
 class ElectionAdmin(admin.ModelAdmin):
     inlines = [CandidateInline]
     actions = [archive]
-    list_filter = ['archive','open', 'vote_type']
+    list_filter = ['archived','open', 'vote_type']
     list_display = ['__str__', 'open','vote_type']
 
 

--- a/votes/forms.py
+++ b/votes/forms.py
@@ -35,33 +35,34 @@ class CandidateForm(ModelForm):
 class IDTicketForm(Form):
     ids = CharField(help_text="A list of whitespace separated uni-ids",
                     widget=Textarea(), label="IDs")
-    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
+    elections = ModelMultipleChoiceField(Election.objects.filter(archived=False))
 
 
 class UsernameTicketForm(Form):
     ids = CharField(help_text="A list of whitespace separated usernames",
                     widget=Textarea(), label="Usernames")
-    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
+    elections = ModelMultipleChoiceField(Election.objects.filter(archived=False))
 
 
 class AllTicketForm(Form):
-    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
+    elections = ModelMultipleChoiceField(Election.objects.filter(archived=False))
 
 
 class MemberTicketForm(Form):
     members = ModelMultipleChoiceField(Member.objects.all())
-    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
+    elections = ModelMultipleChoiceField(Election.objects.filter(archived=False))
 
 
 class DateTicketForm(Form):
     date = DateField(widget=SelectDateWidget(),
                      help_text="Select the date before which their membership should have been verified." + \
                                "Note that this will only select those who are currently members of the society.")
-    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
+    elections = ModelMultipleChoiceField(Election.objects.filter(archived=False))
 
 
 class DeleteTicketForm(Form):
-    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False, open=False))
+    elections = ModelMultipleChoiceField(
+        Election.objects.filter(archived=False, open=False))
 
 
 class NullForm(Form):

--- a/votes/forms.py
+++ b/votes/forms.py
@@ -56,3 +56,7 @@ class DateTicketForm(Form):
                      help_text="Select the date before which their membership should have been verified." + \
                          "Note that this will only select those who are currently members of the society.")
     elections = ModelMultipleChoiceField(Election.objects.all())
+
+
+class DeleteTicketForm(Form):
+    elections = ModelMultipleChoiceField(Election.objects.filter(open=False))

--- a/votes/forms.py
+++ b/votes/forms.py
@@ -64,6 +64,10 @@ class DeleteTicketForm(Form):
     elections = ModelMultipleChoiceField(Election.objects.filter(archive=False, open=False))
 
 
+class NullForm(Form):
+    pass
+
+
 class ResetVoteForm(Form):
     uuid = UUIDField(label="Ticket UUID")
 

--- a/votes/forms.py
+++ b/votes/forms.py
@@ -33,30 +33,30 @@ class CandidateForm(ModelForm):
 class IDTicketForm(Form):
     ids = CharField(help_text="A list of whitespace separated uni-ids",
                     widget=Textarea(), label="IDs")
-    elections = ModelMultipleChoiceField(Election.objects.all())
+    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
 
 
 class UsernameTicketForm(Form):
     ids = CharField(help_text="A list of whitespace separated usernames",
                     widget=Textarea(), label="Usernames")
-    elections = ModelMultipleChoiceField(Election.objects.all())
+    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
 
 
 class AllTicketForm(Form):
-    elections = ModelMultipleChoiceField(Election.objects.all())
+    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
 
 
 class MemberTicketForm(Form):
     members = ModelMultipleChoiceField(Member.objects.all())
-    elections = ModelMultipleChoiceField(Election.objects.all())
+    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
 
 
 class DateTicketForm(Form):
     date = DateField(widget=SelectDateWidget(),
                      help_text="Select the date before which their membership should have been verified." + \
                          "Note that this will only select those who are currently members of the society.")
-    elections = ModelMultipleChoiceField(Election.objects.all())
+    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False))
 
 
 class DeleteTicketForm(Form):
-    elections = ModelMultipleChoiceField(Election.objects.filter(open=False))
+    elections = ModelMultipleChoiceField(Election.objects.filter(archive=False, open=False))

--- a/votes/models.py
+++ b/votes/models.py
@@ -19,7 +19,7 @@ class Election(models.Model):
     seats = models.IntegerField(
         default=1, help_text="Ignored except in STV. Number of people who can win")
     open = models.BooleanField(default=False)
-    archive = models.BooleanField(default=False, verbose_name="archived")
+    archived = models.BooleanField(default=False)
 
     def __str__(self):
         return self.name
@@ -33,6 +33,9 @@ class Election(models.Model):
             return self.stvvote_set.all()
         else:
             raise NotImplemented()
+
+    class Meta:
+        ordering = ('id',)
 
 
 class Candidate(models.Model):

--- a/votes/models.py
+++ b/votes/models.py
@@ -19,6 +19,7 @@ class Election(models.Model):
     seats = models.IntegerField(
         default=1, help_text="Ignored except in STV. Number of people who can win")
     open = models.BooleanField(default=False)
+    archive = models.BooleanField(default=False)
 
     def __str__(self):
         return self.name

--- a/votes/models.py
+++ b/votes/models.py
@@ -19,7 +19,7 @@ class Election(models.Model):
     seats = models.IntegerField(
         default=1, help_text="Ignored except in STV. Number of people who can win")
     open = models.BooleanField(default=False)
-    archive = models.BooleanField(default=False)
+    archive = models.BooleanField(default=False, verbose_name="archived")
 
     def __str__(self):
         return self.name

--- a/votes/templates/votes/admin.html
+++ b/votes/templates/votes/admin.html
@@ -38,7 +38,14 @@
             </a>
         {% endfor %}
     </div>
+
     {% if open_elections %}
+        <p>
+            <a href="{% url "votes:reset_vote" %}"
+               class="btn btn-outline-danger btn-block">
+                Reset User Vote
+            </a>
+        </p>
         <h2>Live Votes</h2>
         <ul class="list-group mb-3">
             {% for election in open_elections %}

--- a/votes/templates/votes/admin.html
+++ b/votes/templates/votes/admin.html
@@ -55,6 +55,13 @@
                 </li>
             {% endfor %}
         </ul>
+        <form class="mb-3" method="post" action="{% url "votes:close" %}">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-outline-success btn-block">
+                Close all votes
+            </button>
+        </form>
+
     {% endif %}
     {% if closed_elections %}
         <h2>Results</h2>

--- a/votes/templates/votes/admin.html
+++ b/votes/templates/votes/admin.html
@@ -1,4 +1,5 @@
 {% extends 'tgrsite/main.html' %}
+{% load vote_tags %}
 
 {% block title %}Votes{% endblock %}
 {% block pagetitle %}Votes{% endblock %}
@@ -26,7 +27,7 @@
     <p>
         <a href="{% url "votes:tickets" %}"
            class="btn btn-outline-success btn-block">
-            Issue Tickets
+            Manage Tickets
         </a>
     </p>
     <div class="list-group mb-3">
@@ -37,16 +38,26 @@
             </a>
         {% endfor %}
     </div>
-    <h2>Results</h2>
-    <div class="list-group">
-        {% for election in object_list %}
-            {% if election.open %}
-            {% else %}
-            <a href="{% url "votes:results" election.id %}"
-               class="list-group-item list-group-item-action">
-                {{ election.name }}
-            </a>
-            {% endif %}
-        {% endfor %}
-    </div>
+    {% if open_elections %}
+        <h2>Live Votes</h2>
+        <ul class="list-group mb-3">
+            {% for election in open_elections %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    {{ election.name }}
+                    <span class="badge badge-primary badge-pill">{{ election|sanitized_vote_count }}</span>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+    {% if closed_elections %}
+        <h2>Results</h2>
+        <div class="list-group">
+            {% for election in closed_elections %}
+                <a href="{% url "votes:results" election.id %}"
+                   class="list-group-item list-group-item-action">
+                    {{ election.name }}
+                </a>
+            {% endfor %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/votes/templates/votes/approval_done.html
+++ b/votes/templates/votes/approval_done.html
@@ -29,6 +29,7 @@
                 <br>
                 <code>{{ object.uuid }}</code>
             </p>
+            <a class="btn btn-large btn-block btn-primary" href="{% url 'votes:elections' %}">Return to list of elections</a>
         </div>
     </div>
 {% endblock %}

--- a/votes/templates/votes/delete_tickets.html
+++ b/votes/templates/votes/delete_tickets.html
@@ -1,0 +1,16 @@
+{% extends 'tgrsite/main.html' %}
+{% load markdown_tags %}
+
+{% block title %}Tickets - Votes{% endblock %}
+{% block pagetitle %}Delete Tickets{% endblock %}
+
+{% block breadcrumbs_parents %}
+    <li class="breadcrumb-item"><a href="{% url 'votes:elections' %}">Votes</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'votes:admin' %}">Admin</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'votes:tickets' %}">Tickets</a></li>
+{% endblock %}
+{% block breadcrumbs_child %}Delete{% endblock %}
+
+{% block body %}
+    {% include "parts/render_form.html" with colour="danger" save="Delete" %}
+{% endblock %}

--- a/votes/templates/votes/home.html
+++ b/votes/templates/votes/home.html
@@ -1,4 +1,5 @@
 {% extends 'tgrsite/main.html' %}
+{% load vote_tags %}
 
 {% block title %}Votes{% endblock %}
 {% block pagetitle %}Votes{% endblock %}
@@ -23,10 +24,18 @@
     {% endif %}
     <div class="list-group">
         {% for election in object_list %}
-            <a href="{% url "votes:vote" election.id %}"
-               class="list-group-item list-group-item-action">
-                {{ election.name }}
-            </a>
+            {% current_user_ticket election as ticket %}
+            {% if ticket.spent %}
+                <p href="{% url "votes:vote" election.id %}"
+                   class="list-group-item list-group-item-light" data-toggle="tooltip" data-placement="top" title="Already Voted">
+                    <i class="fas fa-vote-yea fa-fw"></i> {{ election.name }}
+                </p>
+            {% else %}
+                <a href="{% url "votes:vote" election.id %}"
+                   class="list-group-item list-group-item-action">
+                    <i class="fas fa-file-alt fa-fw"></i> {{ election.name }}
+                </a>
+            {% endif %}
         {% empty %}
             <div class="list-group-item text-muted">No elections currently available. Please check back later.</div>
         {% endfor %}

--- a/votes/templates/votes/reset_vote.html
+++ b/votes/templates/votes/reset_vote.html
@@ -1,0 +1,34 @@
+{% extends 'tgrsite/main.html' %}
+{% load markdown_tags %}
+
+{% block title %}Reset - Votes{% endblock %}
+{% block pagetitle %}Reset Vote{% endblock %}
+
+{% block breadcrumbs_parents %}
+    <li class="breadcrumb-item"><a href="{% url 'votes:elections' %}">Votes</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'votes:admin' %}">Admin</a></li>
+{% endblock %}
+{% block breadcrumbs_child %}Reset Vote{% endblock %}
+
+{% block body %}
+    <div class="card bg-warning mb-3">
+        <h3 class="card-header"><i class="fas fa-exclamation-triangle"></i> Warning</h3>
+        <div class="card-body">
+            <p class="card-text">
+                You should <strong>only</strong> do this at the behest of the person who cast it,
+                and only if they are sure that they want the vote reset.
+            </p>
+            <p class="card-text">
+                If you are even slightly unsure that the vote UUID might not be theirs, you shouldn't delete it.
+            </p>
+            <p class="card-text">
+                This section of the voting system is by far the quickest way to invalidate the election,
+                so please be careful.
+            </p>
+        </div>
+    </div>
+    <p class="card-text">
+        This deletes a specific vote from the election by UUID. Once the vote has been deleted through this method, the user will once again be able to cast a vote in that election.
+    </p>
+    {% include "parts/render_form.html" with colour="danger" save="Reset Vote" %}
+{% endblock %}

--- a/votes/templates/votes/stv_results.html
+++ b/votes/templates/votes/stv_results.html
@@ -12,7 +12,7 @@
     </div>
     <h3>Breakdown</h3>
     <div class="list-group mb-2">
-        {% for i in election.candidate_set.all %}
+        {% for i in election.candidate_set.all|dictsort:"id" %}
             <p class="list-group-item"><strong class="d-inline-block align-middle mr-2" style="width: 2rem">{{ i.id }}</strong><span class="d-inline-block align-middle">{{ i.name }}</span></p>
         {% endfor %}
     </div>

--- a/votes/templates/votes/stv_results.html
+++ b/votes/templates/votes/stv_results.html
@@ -10,6 +10,12 @@
             </div>
         {% endfor %}
     </div>
+    <h3>Breakdown</h3>
+    <div class="list-group mb-2">
+        {% for i in election.candidate_set.all %}
+            <p class="list-group-item"><strong class="d-inline-block align-middle mr-2" style="width: 2rem">{{ i.id }}</strong><span class="d-inline-block align-middle">{{ i.name }}</span></p>
+        {% endfor %}
+    </div>
     <pre>{{ result.full_log }}</pre>
 {% endblock %}
 

--- a/votes/templates/votes/ticket.html
+++ b/votes/templates/votes/ticket.html
@@ -50,4 +50,11 @@
             Specific Member
         </a>
     </p>
+    <h2>Delete Tickets</h2>
+    <p>
+        <a href="{% url "votes:tickets_delete" %}"
+           class="btn btn-outline-danger btn-block">
+            Delete Tickets
+        </a>
+    </p>
 {% endblock %}

--- a/votes/templatetags/vote_tags.py
+++ b/votes/templatetags/vote_tags.py
@@ -3,6 +3,7 @@ import math
 import random
 
 from django import template
+from django.utils.safestring import mark_safe
 
 from votes.models import Election
 
@@ -13,9 +14,9 @@ register = template.Library()
 def sanitized_vote_count(vote: Election):
     value = vote.votes().count()
     if value <= 5:
-        return "<=5"
+        return mark_safe("&le; 5")
     else:
-        return f"{math.floor(value/5)*5}-{math.ceil(value/5)*5}"
+        return f"{math.floor(value/5)*5} - {math.ceil(value/5)*5}"
 
 
 @register.simple_tag(takes_context=True)

--- a/votes/templatetags/vote_tags.py
+++ b/votes/templatetags/vote_tags.py
@@ -1,0 +1,22 @@
+import hashlib
+import math
+import random
+
+from django import template
+
+from votes.models import Election
+
+register = template.Library()
+
+
+@register.filter(is_safe=True)
+def sanitized_vote_count(vote: Election):
+    value = vote.votes().count()
+    if value <= 5:
+        return "0-5"
+    else:
+        seed = hashlib.sha1((str(vote.id) + str(vote.name) + str(value)).encode('utf-8'))
+        generator = random.Random()
+        generator.seed(seed)
+        fuzzed = generator.randrange(math.floor(value * 0.8), math.ceil(value * 1.2))
+        return f"{math.floor(fuzzed * 0.8)}-{math.ceil(fuzzed * 1.2)}"

--- a/votes/templatetags/vote_tags.py
+++ b/votes/templatetags/vote_tags.py
@@ -13,13 +13,9 @@ register = template.Library()
 def sanitized_vote_count(vote: Election):
     value = vote.votes().count()
     if value <= 5:
-        return "0-5"
+        return "<=5"
     else:
-        seed = hashlib.sha1((str(vote.id) + str(vote.name) + str(value)).encode('utf-8'))
-        generator = random.Random()
-        generator.seed(seed)
-        fuzzed = generator.randrange(math.floor(value * 0.8), math.ceil(value * 1.2))
-        return f"{math.floor(fuzzed * 0.8)}-{math.ceil(fuzzed * 1.2)}"
+        return f"{math.floor(value/5)*5}-{math.ceil(value/5)*5}"
 
 
 @register.simple_tag(takes_context=True)

--- a/votes/templatetags/vote_tags.py
+++ b/votes/templatetags/vote_tags.py
@@ -9,7 +9,7 @@ from votes.models import Election
 register = template.Library()
 
 
-@register.filter(is_safe=True)
+@register.filter()
 def sanitized_vote_count(vote: Election):
     value = vote.votes().count()
     if value <= 5:
@@ -20,3 +20,11 @@ def sanitized_vote_count(vote: Election):
         generator.seed(seed)
         fuzzed = generator.randrange(math.floor(value * 0.8), math.ceil(value * 1.2))
         return f"{math.floor(fuzzed * 0.8)}-{math.ceil(fuzzed * 1.2)}"
+
+
+@register.simple_tag(takes_context=True)
+def current_user_ticket(context, election: Election):
+    try:
+        return election.ticket_set.filter(member=context['user'].member).first()
+    except AttributeError:
+        return None

--- a/votes/urls.py
+++ b/votes/urls.py
@@ -3,7 +3,8 @@ from django.urls import path, include
 
 from .views import ApprovalVoteView, DoneView, ApprovalResultView, HomeView, VoteView, FPTPResultView, FPTPVoteView, \
     STVVoteView, STVResultView, UpdateElection, CreateElection, CreateCandidate, UpdateCandidate, AdminView, TicketView, \
-    ResultView, IDTicketView, DateTicketView, STVAllVoteView, AllTicketView, UsernameTicketView, UserTicketView
+    ResultView, IDTicketView, DateTicketView, STVAllVoteView, AllTicketView, UsernameTicketView, UserTicketView, \
+    DeleteTicketView
 
 app_name = "votes"
 
@@ -32,6 +33,7 @@ urlpatterns = [
     path('admin/tickets/username',
          UsernameTicketView.as_view(), name="tickets_username"),
     path('admin/tickets/user', UserTicketView.as_view(), name="tickets_user"),
+    path('admin/tickets/delete', DeleteTicketView.as_view(), name="tickets_delete"),
     path('admin/create/', CreateElection.as_view(), name="create_election"),
     path('admin/edit/<int:election>/',
          UpdateElection.as_view(), name="update_election"),

--- a/votes/urls.py
+++ b/votes/urls.py
@@ -1,5 +1,4 @@
-from django.contrib import admin
-from django.urls import path, include
+from django.urls import path
 
 from .views import ApprovalVoteView, DoneView, ApprovalResultView, HomeView, VoteView, FPTPResultView, FPTPVoteView, \
     STVVoteView, STVResultView, UpdateElection, CreateElection, CreateCandidate, UpdateCandidate, AdminView, TicketView, \
@@ -28,13 +27,14 @@ urlpatterns = [
     path('admin/', AdminView.as_view(), name="admin"),
     path('admin/reset_vote/', ResetVoteView.as_view(), name="reset_vote"),
     path('admin/tickets/', TicketView.as_view(), name="tickets"),
-    path('admin/tickets/id', IDTicketView.as_view(), name="tickets_id"),
-    path('admin/tickets/date', DateTicketView.as_view(), name="tickets_date"),
-    path('admin/tickets/all', AllTicketView.as_view(), name="tickets_all"),
-    path('admin/tickets/username',
+    path('admin/tickets/id/', IDTicketView.as_view(), name="tickets_id"),
+    path('admin/tickets/date/', DateTicketView.as_view(), name="tickets_date"),
+    path('admin/tickets/all/', AllTicketView.as_view(), name="tickets_all"),
+    path('admin/tickets/username/',
          UsernameTicketView.as_view(), name="tickets_username"),
-    path('admin/tickets/user', UserTicketView.as_view(), name="tickets_user"),
-    path('admin/tickets/delete', DeleteTicketView.as_view(), name="tickets_delete"),
+    path('admin/tickets/user/', UserTicketView.as_view(), name="tickets_user"),
+    path('admin/tickets/delete/', DeleteTicketView.as_view(),
+         name="tickets_delete"),
     path('admin/create/', CreateElection.as_view(), name="create_election"),
     path('admin/edit/<int:election>/',
          UpdateElection.as_view(), name="update_election"),

--- a/votes/urls.py
+++ b/votes/urls.py
@@ -4,7 +4,7 @@ from django.urls import path, include
 from .views import ApprovalVoteView, DoneView, ApprovalResultView, HomeView, VoteView, FPTPResultView, FPTPVoteView, \
     STVVoteView, STVResultView, UpdateElection, CreateElection, CreateCandidate, UpdateCandidate, AdminView, TicketView, \
     ResultView, IDTicketView, DateTicketView, STVAllVoteView, AllTicketView, UsernameTicketView, UserTicketView, \
-    DeleteTicketView, ResetVoteView
+    DeleteTicketView, ResetVoteView, CloseElectionView
 
 app_name = "votes"
 
@@ -42,4 +42,5 @@ urlpatterns = [
          CreateCandidate.as_view(), name="create_candidate"),
     path('admin/edit/<int:election>/edit/<int:candidate>/',
          UpdateCandidate.as_view(), name="update_candidate"),
+    path('admin/close_all/', CloseElectionView.as_view(), name="close"),
 ]

--- a/votes/urls.py
+++ b/votes/urls.py
@@ -4,7 +4,7 @@ from django.urls import path, include
 from .views import ApprovalVoteView, DoneView, ApprovalResultView, HomeView, VoteView, FPTPResultView, FPTPVoteView, \
     STVVoteView, STVResultView, UpdateElection, CreateElection, CreateCandidate, UpdateCandidate, AdminView, TicketView, \
     ResultView, IDTicketView, DateTicketView, STVAllVoteView, AllTicketView, UsernameTicketView, UserTicketView, \
-    DeleteTicketView
+    DeleteTicketView, ResetVoteView
 
 app_name = "votes"
 
@@ -26,6 +26,7 @@ urlpatterns = [
     path('<int:election>/results/stv/votes/',
          STVAllVoteView.as_view(), name="stv_all_votes"),
     path('admin/', AdminView.as_view(), name="admin"),
+    path('admin/reset_vote/', ResetVoteView.as_view(), name="reset_vote"),
     path('admin/tickets/', TicketView.as_view(), name="tickets"),
     path('admin/tickets/id', IDTicketView.as_view(), name="tickets_id"),
     path('admin/tickets/date', DateTicketView.as_view(), name="tickets_date"),

--- a/votes/views.py
+++ b/votes/views.py
@@ -159,7 +159,7 @@ class ResetVoteView(PermissionRequiredMixin, FormView):
     success_url = reverse_lazy('votes:admin')
 
     def form_valid(self, form):
-        uuid = form['uuid']
+        uuid = form.cleaned_data['uuid']
         ticket = get_object_or_404(Ticket, uuid=uuid)
         if ticket.election.vote_type == Election.Types.FPTP:
             vote = get_object_or_404(FPTPVote, uuid=uuid)

--- a/votes/views.py
+++ b/votes/views.py
@@ -26,8 +26,13 @@ class HomeView(LoginRequiredMixin, ListView):
     context_object_name = "elections"
 
     def get_queryset(self):
-        tickets = self.request.user.member.ticket_set.filter(spent=False)
+        tickets = self.request.user.member.ticket_set.filter()
         return Election.objects.filter(ticket__in=tickets, open=True)
+
+    def get_context_data(self, *args, **kwargs):
+        ctxt = super().get_context_data(*args, **kwargs)
+        ctxt['tickets'] = self.request.user.member.ticket_set.filter()
+        return ctxt
 
 
 class AdminView(PermissionRequiredMixin, ListView):
@@ -37,7 +42,7 @@ class AdminView(PermissionRequiredMixin, ListView):
     context_object_name = "elections"
 
     def get_queryset(self):
-        return Election.objects.all()
+        return Election.objects.filter(archive=False)
 
     def get_context_data(self, *args, **kwargs):
         ctxt = super().get_context_data(*args, **kwargs)

--- a/votes/views.py
+++ b/votes/views.py
@@ -45,7 +45,7 @@ class AdminView(PermissionRequiredMixin, ListView):
     context_object_name = "elections"
 
     def get_queryset(self):
-        return Election.objects.filter(archive=False).order_by('id')
+        return Election.objects.filter(archived=False).order_by('id')
 
     def get_context_data(self, *args, **kwargs):
         ctxt = super().get_context_data(*args, **kwargs)
@@ -187,7 +187,7 @@ class CloseElectionView(PermissionRequiredMixin, FormView):
     success_url = reverse_lazy('votes:admin')
 
     def form_valid(self, form):
-        Election.objects.filter(open=True, archive=False).update(open=False)
+        Election.objects.filter(open=True, archived=False).update(open=False)
         add_message(self.request, messages.SUCCESS, "All votes closed")
         return super().form_valid(form)
 
@@ -266,7 +266,8 @@ class VoteView(LoginRequiredMixin, RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         election = self.get_object()
         if election.vote_type == Election.Types.APRV:
-            return reverse('votes:approval_vote', args=[self.kwargs['election']])
+            return reverse('votes:approval_vote',
+                           args=[self.kwargs['election']])
         elif election.vote_type == Election.Types.FPTP:
             return reverse('votes:fptp_vote', args=[self.kwargs['election']])
         elif election.vote_type == Election.Types.STV:
@@ -284,7 +285,8 @@ class ResultView(PermissionRequiredMixin, RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         election = self.get_object()
         if election.vote_type == Election.Types.APRV:
-            return reverse('votes:approval_results', args=[self.kwargs['election']])
+            return reverse('votes:approval_results',
+                           args=[self.kwargs['election']])
         elif election.vote_type == Election.Types.FPTP:
             return reverse('votes:fptp_results', args=[self.kwargs['election']])
         elif election.vote_type == Election.Types.STV:
@@ -301,7 +303,8 @@ class ApprovalResultView(PermissionRequiredMixin, ListView):
     context_object_name = "choices"
 
     def get_queryset(self):
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], vote_type=Election.Types.APRV,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          vote_type=Election.Types.APRV,
                                           open=False)
         return self.election.candidate_set.all()
 
@@ -327,7 +330,6 @@ class ApprovalVoteView(UserPassesTestMixin, TemplateView):
         self.get_context_data(**kwargs)
         ticket = get_object_or_404(
             request.user.member.ticket_set.all(), election=self.election, spent=False)
-        print(request.POST)
         errors = []
         if "selection" not in request.POST:
             errors.append("Please select at least one option")
@@ -379,7 +381,8 @@ class FPTPResultView(PermissionRequiredMixin, ListView):
     context_object_name = "choices"
 
     def get_queryset(self):
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], vote_type=Election.Types.FPTP,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          vote_type=Election.Types.FPTP,
                                           open=False)
         return self.election.candidate_set.all()
 
@@ -397,14 +400,17 @@ class FPTPVoteView(UserPassesTestMixin, TemplateView):
     def test_func(self):
         if self.request.user.is_anonymous:
             return False
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], open=True,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          open=True,
                                           vote_type=Election.Types.FPTP)
-        return self.request.user.member.ticket_set.filter(election=self.election, spent=False).exists()
+        return self.request.user.member.ticket_set.filter(
+            election=self.election, spent=False).exists()
 
     def post(self, request, **kwargs):
         self.get_context_data(**kwargs)
         ticket = get_object_or_404(
-            request.user.member.ticket_set.all(), election=self.election, spent=False)
+            request.user.member.ticket_set.all(), election=self.election,
+            spent=False)
         print(request.POST)
         errors = []
         if "selection" not in request.POST:
@@ -434,11 +440,13 @@ class FPTPVoteView(UserPassesTestMixin, TemplateView):
             ticket.save()
 
             return HttpResponseRedirect(
-                reverse("votes:vote_done", kwargs={'election': self.election.id, 'slug': vote.uuid}))
+                reverse("votes:vote_done", kwargs={'election': self.election.id,
+                                                   'slug': vote.uuid}))
 
     def get_context_data(self, **kwargs):
         ctxt = super().get_context_data(**kwargs)
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], open=True,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          open=True,
                                           vote_type=Election.Types.FPTP)
         ctxt['election'] = self.election
         ctxt['choices'] = list(self.election.candidate_set.all())
@@ -453,7 +461,8 @@ class STVResultView(PermissionRequiredMixin, ListView):
     context_object_name = "choices"
 
     def get_queryset(self):
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], vote_type=Election.Types.STV,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          vote_type=Election.Types.STV,
                                           open=False)
         return self.election.candidate_set.all()
 
@@ -465,12 +474,14 @@ class STVResultView(PermissionRequiredMixin, ListView):
         except STVResult.DoesNotExist:
             candidates = set(
                 map(attrgetter('id'), self.election.candidate_set.all()))
-            withdrawn = set(map(attrgetter('id'), self.election.candidate_set.filter(
-                state=Candidate.State.WITHDRAWN)))
+            withdrawn = set(
+                map(attrgetter('id'), self.election.candidate_set.filter(
+                    state=Candidate.State.WITHDRAWN)))
             votes = []
             for i in self.election.stvvote_set.all():
                 vote = []
-                for j in STVPreference.objects.filter(stvvote=i).order_by('order'):
+                for j in STVPreference.objects.filter(stvvote=i).order_by(
+                        'order'):
                     vote.append(int(j.candidate_id))
                 votes.append(tuple(vote))
 
@@ -492,13 +503,17 @@ class STVVoteView(UserPassesTestMixin, TemplateView):
         if self.request.user.is_anonymous:
             return False
         self.election = get_object_or_404(
-            Election, id=self.kwargs['election'], open=True, vote_type=Election.Types.STV)
-        return self.request.user.member.ticket_set.filter(election=self.election, spent=False).exists()
+            Election, id=self.kwargs['election'], open=True,
+            vote_type=Election.Types.STV)
+        return self.request.user.member.ticket_set.filter(
+            election=self.election, spent=False).exists()
 
     def post(self, request, **kwargs):
         self.get_context_data(**kwargs)
         ticket = get_object_or_404(
-            request.user.member.ticket_set.all(), election=self.election, spent=False)
+            request.user.member.ticket_set.all(),
+            election=self.election,
+            spent=False)
         print(request.POST)
         errors = []
         allowed = set(a.id for a in self.election.candidate_set.all())
@@ -550,7 +565,9 @@ class STVVoteView(UserPassesTestMixin, TemplateView):
             ticket.save()
 
             return HttpResponseRedirect(
-                reverse("votes:vote_done", kwargs={'election': self.election.id, 'slug': vote.uuid}))
+                reverse("votes:vote_done",
+                        kwargs={'election': self.election.id,
+                                'slug': vote.uuid}))
 
     def get_context_data(self, **kwargs):
         ctxt = super().get_context_data(**kwargs)
@@ -569,7 +586,8 @@ class STVAllVoteView(PermissionRequiredMixin, ListView):
     context_object_name = "choices"
 
     def get_queryset(self):
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], vote_type=Election.Types.STV,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          vote_type=Election.Types.STV,
                                           open=False)
         return self.election.candidate_set.all()
 


### PR DESCRIPTION
Changes include:
Upstreaming changes from UWCS (adds a back to vote list on voted page and archived flag for votes)
Adds a key for stv breakdowns so you don't have to look it up
Adds a big easy button for deleting tickets at end of vote (so that you don't get 500 errors when deleting too many tickets)
Shows approximate vote counts for active votes (chunked to 5 votes)
Hides bits of the admin page when empty
Allows users to still see votes they voted in on the dashboard page while the election is active (grayed out and unclickable)
Adds a dedicated UI for resetting a vote from UUID. This helps prevent you from doing it wrong, as well as accidentally seeing the vote itself
Adds a button to close all active votes.
