### PR TITLE
Fix double event creation

### DIFF
--- a/rpgs/templates/rpgs/create.html
+++ b/rpgs/templates/rpgs/create.html
@@ -8,5 +8,5 @@
 {% block breadcrumbs_child %}Create{% endblock %}
 
 {% block body %}
-    {% include "parts/render_form.html" %}
+    {% include "parts/render_form.html" with idempotent=1 %}
 {% endblock %}

--- a/rpgs/views.py
+++ b/rpgs/views.py
@@ -17,6 +17,7 @@ from django.views import generic
 from messaging.views import create_group
 from notifications.models import NotifType
 from notifications.utils import notify, notify_everybody, notify_discord
+from templatetags.lib import IdempotentMixin
 from templatetags.templatetags.markdown_tags import parse_md_text
 from .forms import RpgForm, RpgCreateForm
 from .models import Rpg, Tag
@@ -98,7 +99,7 @@ def notify_rpg(object):
     object.save()
 
 
-class Create(LoginRequiredMixin, generic.CreateView):
+class Create(LoginRequiredMixin, IdempotentMixin, generic.CreateView):
     template_name = 'rpgs/create.html'
     model = Rpg
     form_class = RpgCreateForm

--- a/templatetags/lib.py
+++ b/templatetags/lib.py
@@ -1,0 +1,65 @@
+import uuid
+
+from django.http import HttpResponseRedirect, HttpResponseBadRequest, HttpResponse
+from django.http.response import HttpResponseRedirectBase
+from django.views import View
+
+from .models import IdempotencyToken
+
+
+class HttpResponseNoContent(HttpResponse):
+    """Special HTTP response with no content, just headers.
+
+    The content operations are ignored.
+    """
+
+    def __init__(self, content="", mimetype=None, status=None, content_type=None):
+        super().__init__(status=204)
+
+        if "content-type" in self._headers:
+            del self._headers["content-type"]
+
+    def _set_content(self, value):
+        pass
+
+    def _get_content(self, value):
+        pass
+
+def is_valid_uuid(val):
+    try:
+        uuid.UUID(str(val))
+        return True
+    except ValueError:
+        return False
+
+class IdempotentMixin(View):
+    def dispatch(self, request, *args, **kwargs):
+        if request.method == "POST":
+            if "_idempotency_token" in request.POST and is_valid_uuid(request.POST['_idempotency_token']):
+                normalised_uuid = str(uuid.UUID(request.POST['_idempotency_token']))
+                try:
+                    i = IdempotencyToken.objects.get(token=normalised_uuid)
+                    # Seen the request before, so need to short circuit
+                    if i.redirect:
+                        # Try to return saved redirect
+                        return HttpResponseRedirect(i.redirect)
+                    try:
+                        # No redirect was saved, so try to generate one
+                        return HttpResponseRedirect(self.get_success_url())
+                    except Exception:
+                        # Otherwise return a generic success code
+                        return HttpResponseNoContent()
+                except IdempotencyToken.DoesNotExist:
+                    # Haven't seen this token before, so safe to do main action
+                    # Save the token first to avoid repeats
+                    i = IdempotencyToken.objects.create(token=normalised_uuid)
+                    # Perform the intended action
+                    resp = super().dispatch(request, *args, **kwargs)
+                    # Save the redirect if we can
+                    if isinstance(resp, HttpResponseRedirectBase):
+                        i.redirect = resp.url
+                        i.save()
+                    return resp
+            else:
+                return HttpResponseBadRequest("Missing required internal form attribute")
+        return super().dispatch(request, *args, **kwargs)

--- a/templatetags/models.py
+++ b/templatetags/models.py
@@ -1,3 +1,8 @@
 from django.db import models
 
+
 # Create your models here.
+class IdempotencyToken(models.Model):
+    token = models.UUIDField()
+    created = models.DateTimeField(auto_now_add=True)
+    redirect = models.CharField(max_length=2048, blank=True)

--- a/tgrsite/templates/parts/render_form.html
+++ b/tgrsite/templates/parts/render_form.html
@@ -1,6 +1,9 @@
 {% load crispy_forms_filters %}
 <form class="mb-2" method="post">
     {% csrf_token %}
+    {% if idempotent %}
+    <input type="hidden" name="_idempotency_token" data-wtt-idempotency="true">
+    {% endif %}
     {{ form|crispy }}
     <input type="submit" class="form-control btn-outline-{% if colour %}{{ colour }}{% else %}primary{% endif %}" value="{% if save %}{{ save }}{% else %}Save{% endif %}">
 </form>

--- a/tgrsite/templates/tgrsite/main.html
+++ b/tgrsite/templates/tgrsite/main.html
@@ -97,7 +97,8 @@ THIS IS USED BY THE SITE
                     {% endif %}
                     {% if request.user.is_authenticated %}
                         <li><a class="card-link" href="{% url 'users:me' %}">My profile</a></li>
-                        <li><a class="card-link" href="{% url 'notifications:notification_settings' %}">Notification and Email Settings</a></li>
+                        <li><a class="card-link" href="{% url 'notifications:notification_settings' %}">Notification and
+                            Email Settings</a></li>
                         <li><a class="card-link" href="{% url 'users:logout' %}">Log out</a></li>
                     {% else %}
                         <li><a class="card-link" href="{% url 'users:login' %}">Log in</a> / <a class="card-link ml-0"
@@ -137,6 +138,8 @@ THIS IS USED BY THE SITE
     <script src="{% static 'bootstrap3-typeahead.min.js' %}"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"
             integrity="sha256-0H3Nuz3aug3afVbUlsu12Puxva3CP4EhJtPExqs54Vg=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/uuid@8.3.2/dist/umd/uuidv4.min.js"
+            integrity="sha256-S7uAbnQ+Ibyfl7YvwFZOCIm38x7p1Iw/K4XU4A/mKcw=" crossorigin="anonymous"></script>
     {# Markdown editor #}
     <script src="{% static "markdown-editor.min.js" %}"></script>
     <script>
@@ -146,6 +149,12 @@ THIS IS USED BY THE SITE
             $(".markdown-input").MarkdownEditor(false);
             $('[data-toggle="tooltip"]').tooltip();
             $('[data-target="#helpmodal"]').tooltip();
+            $('[data-wtt-idempotency="true"]').val((index, value) => {
+                if (value === "") {
+                    return uuidv4()
+                }
+                return value
+            });
         });
 
         function setCookieForeverish(cname, cvalue) {


### PR DESCRIPTION
Add idempotency tokens to event creation requests to avoid multiple events being created in error. The system should be flexible enough that it can be added to other forms in the future if it is needed