### PR TITLE
Sort forum threads by last update, not just thread creation date

### DIFF
--- a/forum/models.py
+++ b/forum/models.py
@@ -126,6 +126,12 @@ class Thread(models.Model):
     def get_response_count(self):
         return Response.objects.filter(thread=self.id).count()
 
+    def last_update(self):
+        try:
+            return self.response_set.latest('pub_date').pub_date
+        except Response.DoesNotExist as e:
+            return self.pub_date
+
     def get_all_authors(self):
         authors = [x.author for x in self.response_set.all()]
         authors.append(self.author)
@@ -148,7 +154,7 @@ class Response(models.Model):
 
     def __str__(self):
         # TODO: probably strip markdown
-        return self.body
+        return f"{self.thread}: {self.author}"
 
     def get_author(self):
         return Member.objects.get(id=self.author.id)

--- a/forum/templates/forum/parts/thread_list.html
+++ b/forum/templates/forum/parts/thread_list.html
@@ -5,7 +5,7 @@
         <a href="{% url 'forum:viewthread' thread.id %}" class="list-group-item list-group-item-action flex-column">
             <span class="d-flex flex-column flex-sm-row justify-content-between align-items-baseline">
                 <strong>{% if thread.is_pinned %}<i class="fas fa-thumbtack"></i> {% endif%}{% if thread.is_locked %}<i class="fas fa-lock"></i> {% endif%}{{ thread.title }}</strong>
-                <span class="text-muted text-right flex-sm-shrink-0 ml-sm-2">{{ thread.pub_date|timesince }} ago</span>
+                <span class="text-muted text-right flex-sm-shrink-0 ml-sm-2">{{ thread.last_update|timesince }} ago</span>
             </span>
             <span class="d-flex flex-column flex-sm-row justify-content-between align-items-baseline">
                 {% if not userless %}{% include "parts/render_member.html" with member=thread.author nolink=True short=True %}

--- a/forum/views.py
+++ b/forum/views.py
@@ -58,11 +58,11 @@ class ViewSubforum(AccessMixin, SuccessMessageMixin, CreateView):
         current_forum = get_object_or_404(Forum, id=self.kwargs['forum'])
         # put pinned/stickied threads first
         threads = Thread.objects.filter(forum_id=self.kwargs['forum']).extra(
-            order_by=['-is_pinned', '-pub_date'])
+            order_by=['-is_pinned'])
         context.update({
             'current': current_forum,
             'forums': current_forum.get_subforums().order_by('sort_index'),
-            'threads': threads
+            'threads': sorted(threads, key=lambda s:(s.is_pinned, s.last_update()), reverse=True)
         })
         return context
 


### PR DESCRIPTION
Update forum sorting and thread annotation to sort by last response (then post date if missing), not just thread creation. Closes #330.