### PR TITLE
Fix bug where pagination doesn't wrap when viewing past events on the events page

### DIFF
--- a/bootstrap/source/_pagination.scss
+++ b/bootstrap/source/_pagination.scss
@@ -1,5 +1,6 @@
 .pagination {
   display: flex;
+  overflow: scroll;
   @include list-unstyled();
   @include border-radius();
 }


### PR DESCRIPTION
This fixes #337 by causing the pagination to scroll.